### PR TITLE
Add PixiJS example with rectangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# chatgpt_exp1
+# PixiJS Rectangle Demo
+
+This repository contains a simple setup for rendering a rectangle using PixiJS. It includes basic HTML, CSS and JavaScript files to get started quickly.
+
+## How to run
+
+Open `index.html` in a modern web browser. The page loads PixiJS from a CDN and displays a red square centered on a blue background.
+
+No build step is required; just open the file directly or host it with any static file server.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PixiJS Rectangle Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>PixiJS Rectangle Demo</h1>
+    <div id="canvas-container"></div>
+
+    <script src="https://pixijs.download/release/pixi.min.js"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,19 @@
+// Create PixiJS application
+const app = new PIXI.Application({
+    width: window.innerWidth,
+    height: window.innerHeight * 0.9,
+    backgroundColor: 0x1099bb,
+});
+
+document.getElementById('canvas-container').appendChild(app.view);
+
+// Draw a rectangle
+const rectangle = new PIXI.Graphics();
+rectangle.beginFill(0xde3249);
+rectangle.drawRect(0, 0, 100, 100);
+rectangle.endFill();
+
+rectangle.x = app.renderer.width / 2 - 50;
+rectangle.y = app.renderer.height / 2 - 50;
+
+app.stage.addChild(rectangle);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,12 @@
+body {
+    margin: 0;
+    padding: 0;
+    background-color: #f0f0f0;
+    font-family: Arial, sans-serif;
+    text-align: center;
+}
+
+#canvas-container {
+    width: 100vw;
+    height: 90vh;
+}


### PR DESCRIPTION
## Summary
- set up a simple PixiJS demo
- render a red rectangle in a blue background
- add basic styling and instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685029a116608321b41bf23733fb8dd8