### PR TITLE
Add scoreboard overlay to merge game

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,15 @@
 <body>
     <h1>Item Merge Game</h1>
     <p>New circles appear every second. When two circles of the same level collide, they combine into the next level.</p>
-    <div id="canvas-container"></div>
+    <div id="canvas-container">
+        <div id="scoreboard">
+            <span id="score-reputation">Reputation: 0</span>
+            <span id="score-magic">Magic: 0</span>
+            <span id="score-money">Money: 0</span>
+            <span id="score-extra1"></span>
+            <span id="score-extra2"></span>
+        </div>
+    </div>
 
     <script src="https://pixijs.download/release/pixi.min.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -15,6 +15,20 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     document.getElementById('canvas-container').appendChild(app.canvas);
 
+    const scoreEls = {
+        reputation: document.getElementById('score-reputation'),
+        magic: document.getElementById('score-magic'),
+        money: document.getElementById('score-money'),
+    };
+    const scores = { reputation: 0, magic: 0, money: 0 };
+
+    function updateScores() {
+        scoreEls.reputation.textContent = `Reputation: ${scores.reputation}`;
+        scoreEls.magic.textContent = `Magic: ${scores.magic}`;
+        scoreEls.money.textContent = `Money: ${scores.money}`;
+    }
+    updateScores();
+
     const items = [];
     const itemRadius = 20;
     const itemSpeed = 2;
@@ -129,6 +143,10 @@ window.addEventListener('DOMContentLoaded', async () => {
                         items.splice(j, 1);
                         items.splice(i, 1);
                         spawnItem(resultCode, newX, newY);
+                        scores.reputation += 1;
+                        scores.magic += 1;
+                        scores.money += 1;
+                        updateScores();
                         return; // restart detection next tick
                     } else {
                         // simple velocity swap if no merge rule

--- a/style.css
+++ b/style.css
@@ -9,4 +9,19 @@ body {
 #canvas-container {
     width: 100vw;
     height: 90vh;
+    position: relative;
+}
+
+#scoreboard {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-evenly;
+    color: #ffffff;
+    font-weight: bold;
+    pointer-events: none;
+    z-index: 10;
+    padding: 4px 0;
 }


### PR DESCRIPTION
## Summary
- overlay scoreboard at top of game pane
- style scoreboard and canvas container
- track Reputation, Magic and Money scores and update on merges
- keep empty slots for future scores

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68563551fe4083218577ae84e97196f9