### PR TITLE
Add item endpoint for rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <h1>Item Merge Game</h1>
-    <p>New circles appear every second. When two circles of the same level collide, they combine into the next level.</p>
+    <p>New circles appear every second. When two circles of the same level collide, they combine into the next level. Drag items to the dark circle in the bottom-right to convert them into resources.</p>
     <div id="canvas-container">
         <div id="scoreboard">
             <span id="score-reputation">Reputation: 0</span>


### PR DESCRIPTION
## Summary
- add endpoint node to gather items
- collect resource rewards when items reach the endpoint
- mention the endpoint in the instructions

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_68563784de5c8321b55381baa38b1b32