### PR TITLE
Add info pane with item list tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,21 @@
 <body>
     <h1>Item Merge Game</h1>
     <p>New circles appear every second. When two circles of the same level collide, they combine into the next level. Drag items to the dark circle in the bottom-right to convert them into resources.</p>
-    <div id="canvas-container">
-        <div id="scoreboard">
-            <span id="score-reputation">Reputation: 0</span>
-            <span id="score-magic">Magic: 0</span>
-            <span id="score-money">Money: 0</span>
-            <span id="score-extra1"></span>
-            <span id="score-extra2"></span>
+    <div id="game-wrapper">
+        <div id="canvas-container">
+            <div id="scoreboard">
+                <span id="score-reputation">Reputation: 0</span>
+                <span id="score-magic">Magic: 0</span>
+                <span id="score-money">Money: 0</span>
+                <span id="score-extra1"></span>
+                <span id="score-extra2"></span>
+            </div>
+        </div>
+        <div id="info-pane">
+            <div class="tab-buttons">
+                <button class="tab-button active" data-tab="item-list">Items</button>
+            </div>
+            <div id="item-list" class="tab active"></div>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -15,12 +15,32 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     document.getElementById('canvas-container').appendChild(app.canvas);
 
-    const scoreEls = {
-        reputation: document.getElementById('score-reputation'),
-        magic: document.getElementById('score-magic'),
-        money: document.getElementById('score-money'),
-    };
-    const scores = { reputation: 0, magic: 0, money: 0 };
+      const scoreEls = {
+          reputation: document.getElementById('score-reputation'),
+          magic: document.getElementById('score-magic'),
+          money: document.getElementById('score-money'),
+      };
+      const scores = { reputation: 0, magic: 0, money: 0 };
+      
+      const itemListEl = document.getElementById('item-list');
+
+      function refreshItemList() {
+          itemListEl.innerHTML = '';
+          for (const item of items) {
+              const div = document.createElement('div');
+              div.textContent = `#${item.id} ${item.code}`;
+              itemListEl.appendChild(div);
+          }
+      }
+
+      document.querySelectorAll('.tab-button').forEach(btn => {
+          btn.addEventListener('click', () => {
+              document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
+              document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+              btn.classList.add('active');
+              document.getElementById(btn.dataset.tab).classList.add('active');
+          });
+      });
 
     const endpointRadius = 30;
     const endpointX = app.renderer.width - endpointRadius - 20;
@@ -114,6 +134,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
         app.stage.addChild(container);
         items.push(container);
+        refreshItemList();
     }
 
     function isColliding(a, b) {
@@ -165,6 +186,7 @@ window.addEventListener('DOMContentLoaded', async () => {
                 updateScores();
                 app.stage.removeChild(item);
                 items.splice(i, 1);
+                refreshItemList();
                 continue;
             }
         }

--- a/style.css
+++ b/style.css
@@ -6,8 +6,12 @@ body {
     text-align: center;
 }
 
+#game-wrapper {
+    display: flex;
+}
+
 #canvas-container {
-    width: 100vw;
+    flex: 1;
     height: 90vh;
     position: relative;
 }
@@ -24,4 +28,39 @@ body {
     pointer-events: none;
     z-index: 10;
     padding: 4px 0;
+}
+
+#info-pane {
+    width: 250px;
+    height: 90vh;
+    overflow-y: auto;
+    background: #ffffff;
+    border-left: 1px solid #ccc;
+}
+
+.tab-buttons {
+    display: flex;
+    background: #eee;
+}
+
+.tab-button {
+    flex: 1;
+    padding: 4px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    background: #eee;
+}
+
+.tab-button.active {
+    background: #ddd;
+}
+
+.tab {
+    display: none;
+    padding: 4px;
+    text-align: left;
+}
+
+.tab.active {
+    display: block;
 }


### PR DESCRIPTION
## Summary
- redesign layout with new `game-wrapper` container
- add `info-pane` with tab buttons and item list tab
- style new pane and tabs in CSS
- implement tab switch logic and item list updates in JS

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68563939392483218f85b702fb95092e