### PR TITLE
Handle terminal item scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project showcases a small merge game built with PixiJS. Circles are created
 in the center of the screen and move in random directions. When two circles of
 the same level collide, they combine into a higher level circle. Hold the mouse
 button and move around to use the mixing tool, which repels nearby circles.
+Drag a finished item to the dark circle in the bottom-right corner to convert it
+into score. Items that can still be merged will simply bounce off of this zone.
 
 ## How to run
 

--- a/main.js
+++ b/main.js
@@ -166,6 +166,16 @@ window.addEventListener('DOMContentLoaded', async () => {
         return dist < endpointRadius + itemRadius;
     }
 
+    function isTerminalCode(code) {
+        for (const key of Object.keys(mergeRules)) {
+            const parts = key.split('+');
+            if (parts.includes(code)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     app.ticker.add(() => {
         for (let i = items.length - 1; i >= 0; i--) {
             const item = items[i];
@@ -191,15 +201,29 @@ window.addEventListener('DOMContentLoaded', async () => {
             }
 
             if (atEndpoint(item)) {
-                const reward = endpointRewards[item.code] || {};
-                scores.money += reward.money || 0;
-                scores.magic += reward.magic || 0;
-                scores.reputation += reward.reputation || 0;
-                updateScores();
-                app.stage.removeChild(item);
-                items.splice(i, 1);
-                refreshItemList();
-                continue;
+                if (isTerminalCode(item.code)) {
+                    const reward = endpointRewards[item.code] || {};
+                    scores.money += reward.money || 0;
+                    scores.magic += reward.magic || 0;
+                    scores.reputation += reward.reputation || 0;
+                    updateScores();
+                    app.stage.removeChild(item);
+                    items.splice(i, 1);
+                    refreshItemList();
+                    continue;
+                } else {
+                    // bounce back if not terminal
+                    const dx = item.x - endpointX;
+                    const dy = item.y - endpointY;
+                    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                    const nx = dx / dist;
+                    const ny = dy / dist;
+                    const overlap = endpointRadius + itemRadius - dist;
+                    item.x += nx * overlap;
+                    item.y += ny * overlap;
+                    item.vx *= -1;
+                    item.vy *= -1;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- bounce non-terminal items away from the END point
- only award rewards when terminal items touch the END point
- mention this mechanic in README

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68563daebb948321b7eabb0c623c3799