### PR TITLE
Show final items in recipe list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ the same level collide, they combine into a higher level circle. Hold the mouse
 button and move around to use the mixing tool, which repels nearby circles.
 Drag a finished item to the dark circle in the bottom-right corner to convert it
 into score. Items that can still be merged will simply bounce off of this zone.
+Recipes indicate whether the result is a final item. Final items disappear
+immediately when created and are turned into score instead of remaining on the
+board.
 
 ## How to run
 

--- a/main.js
+++ b/main.js
@@ -48,8 +48,9 @@ window.addEventListener('DOMContentLoaded', async () => {
                     if (reward.reputation) parts.push(`Rep ${reward.reputation}`);
                     rewardTxt = ' (' + parts.join(', ') + ')';
                 }
+                const finalFlag = isTerminalCode(result) ? ' [Final]' : '';
                 const div = document.createElement('div');
-                div.textContent = `${a} + ${b} -> ${result}${rewardTxt}`;
+                div.textContent = `${a} + ${b} -> ${result}${finalFlag}${rewardTxt}`;
                 recipeListEl.appendChild(div);
             }
         }


### PR DESCRIPTION
## Summary
- highlight final results in the recipe list
- document that recipes show which results are final items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685643d6c1b88321afaf24e7858d3788