### PR TITLE
Add magic-cost merge items

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ in the center of the screen and move in random directions. When two circles of
 the same level collide, they combine into a higher level circle. Hold the mouse
 button and move around to use the mixing tool, which repels nearby circles.
 Several additional item types and merge results have been introduced so there is
-more variety while playing.
+more variety while playing. Some advanced recipes now require spending Magic to
+complete the merge. If you don't have enough Magic, those merges will fail.
 Drag a finished item to the dark circle in the bottom-right corner to convert it
 into score. Items that can still be merged will simply bounce off of this zone.
 Recipes indicate whether the result is a final item. There are now three

--- a/items.json
+++ b/items.json
@@ -6,5 +6,7 @@
   {"id":5, "code":"EE", "color":"#ff55ff"},
   {"id":6, "code":"FF", "color":"#55ffff"},
   {"id":7, "code":"GG", "color":"#ffaa00"},
-  {"id":8, "code":"HH", "color":"#8888ff"}
+  {"id":8, "code":"HH", "color":"#8888ff"},
+  {"id":9, "code":"II", "color":"#dd4477"},
+  {"id":10, "code":"JJ", "color":"#77dd44"}
 ]

--- a/main.js
+++ b/main.js
@@ -49,9 +49,11 @@ window.addEventListener('DOMContentLoaded', async () => {
                     if (reward.reputation) parts.push(`Rep ${reward.reputation}`);
                     rewardTxt = ' (' + parts.join(', ') + ')';
                 }
+                const cost = mergeCosts[key] || 0;
+                const costTxt = cost ? ` [Cost: ${cost} Mag]` : '';
                 const finalFlag = isTerminalCode(result) ? ' [Final]' : '';
                 const div = document.createElement('div');
-                div.textContent = `${a} + ${b} -> ${result}${finalFlag}${rewardTxt}`;
+                div.textContent = `${a} + ${b} -> ${result}${finalFlag}${rewardTxt}${costTxt}`;
                 recipeListEl.appendChild(div);
             }
         }
@@ -100,7 +102,9 @@ window.addEventListener('DOMContentLoaded', async () => {
         'EE': { reputation: 2, magic: 2 },
         'FF': { money: 3, magic: 2 },
         'GG': { reputation: 3, money: 1 },
-        'HH': { magic: 3, reputation: 1 }
+        'HH': { magic: 3, reputation: 1 },
+        'II': { magic: 4, reputation: 2 },
+        'JJ': { money: 4, reputation: 2 }
     };
 
     function updateScores() {
@@ -145,7 +149,14 @@ window.addEventListener('DOMContentLoaded', async () => {
         'DD+DD': 'EE',
         'EE+EE': 'FF',
         'BB+DD': 'GG',
-        'CC+EE': 'HH'
+        'CC+EE': 'HH',
+        'GG+GG': 'II',
+        'HH+HH': 'JJ'
+    };
+
+    const mergeCosts = {
+        'GG+GG': 2,
+        'HH+HH': 3
     };
 
     let nextItemId = 1;
@@ -278,7 +289,9 @@ window.addEventListener('DOMContentLoaded', async () => {
                 if (isColliding(a, b)) {
                     const key = mergeKey(a.code, b.code);
                     const resultCode = mergeRules[key];
-                    if (resultCode) {
+                    const cost = mergeCosts[key] || 0;
+                    if (resultCode && scores.magic >= cost) {
+                        scores.magic -= cost;
                         const newX = (a.x + b.x) / 2;
                         const newY = (a.y + b.y) / 2;
                         app.stage.removeChild(a);
@@ -299,7 +312,7 @@ window.addEventListener('DOMContentLoaded', async () => {
                         updateScores();
                         return; // restart detection next tick
                     } else {
-                        // simple velocity swap if no merge rule
+                        // simple velocity swap if no merge rule or insufficient magic
                         const tvx = a.vx; const tvy = a.vy;
                         a.vx = b.vx; a.vy = b.vy;
                         b.vx = tvx; b.vy = tvy;


### PR DESCRIPTION
## Summary
- extend items with `II` and `JJ`
- add merge rules that consume Magic when combining certain items
- show magic costs in the recipe list
- reward and deduct magic for new merges
- document magic-cost merges in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68564c4745cc8321973141931de61d7f