### PR TITLE
Add gathering site shop upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Recipes indicate whether the result is a final item. There are now three
 possible final results. Final items disappear immediately when created and are
 turned into score instead of remaining on the board.
 You can also open the **Shop** tab to spend money on a recipe book which adds
-extra merge combinations.
+extra merge combinations. As your reputation increases, you'll be able to
+unlock an additional **Gathering Site** from the shop. Purchasing the site does
+not consume reputation, but it will periodically generate new items that cannot
+be created through merging.
 
 ## How to run
 

--- a/items.json
+++ b/items.json
@@ -8,5 +8,7 @@
   {"id":7, "code":"GG", "color":"#ffaa00"},
   {"id":8, "code":"HH", "color":"#8888ff"},
   {"id":9, "code":"II", "color":"#dd4477"},
-  {"id":10, "code":"JJ", "color":"#77dd44"}
+  {"id":10, "code":"JJ", "color":"#77dd44"},
+  {"id":11, "code":"KK", "color":"#ff8800"},
+  {"id":12, "code":"LL", "color":"#00aaff"}
 ]

--- a/main.js
+++ b/main.js
@@ -65,6 +65,22 @@ window.addEventListener('DOMContentLoaded', async () => {
         };
         let recipeBookPurchased = false;
 
+        const gatherItemCodes = ['KK', 'LL'];
+        const gatherRepRequirement = 5;
+        let gatherSitePurchased = false;
+        let gatherIntervalId = null;
+
+        function startGatherSite() {
+            if (gatherIntervalId) return;
+            gatherIntervalId = setInterval(() => {
+                spawnItem(randomGatherCode());
+            }, 3000);
+        }
+
+        function randomGatherCode() {
+            return gatherItemCodes[Math.floor(Math.random() * gatherItemCodes.length)];
+        }
+
         function refreshShop() {
             shopEl.innerHTML = '';
             const btn = document.createElement('button');
@@ -80,6 +96,22 @@ window.addEventListener('DOMContentLoaded', async () => {
                 refreshShop();
             });
             shopEl.appendChild(btn);
+
+            const gatherBtn = document.createElement('button');
+            if (gatherSitePurchased) {
+                gatherBtn.textContent = 'Gathering Site Purchased';
+                gatherBtn.disabled = true;
+            } else {
+                gatherBtn.textContent = `Buy Gathering Site (requires ${gatherRepRequirement} Rep)`;
+                gatherBtn.disabled = scores.reputation < gatherRepRequirement;
+                gatherBtn.addEventListener('click', () => {
+                    if (gatherSitePurchased || scores.reputation < gatherRepRequirement) return;
+                    gatherSitePurchased = true;
+                    startGatherSite();
+                    refreshShop();
+                });
+            }
+            shopEl.appendChild(gatherBtn);
         }
 
       document.querySelectorAll('.tab-button').forEach(btn => {
@@ -104,7 +136,9 @@ window.addEventListener('DOMContentLoaded', async () => {
         'GG': { reputation: 3, money: 1 },
         'HH': { magic: 3, reputation: 1 },
         'II': { magic: 4, reputation: 2 },
-        'JJ': { money: 4, reputation: 2 }
+        'JJ': { money: 4, reputation: 2 },
+        'KK': { money: 2, reputation: 1 },
+        'LL': { magic: 2, reputation: 1 }
     };
 
     function updateScores() {


### PR DESCRIPTION
## Summary
- include new `KK` and `LL` item definitions
- allow purchasing a Gathering Site from the shop once enough reputation is earned
- Gathering Site periodically spawns the new items which have no merge recipes
- document the Gathering Site in README

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('items.json','utf8')); console.log('JSON ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68564e21cdb883219546b33d1b7e1451