### PR TITLE
Add video background support in info pane

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             </div>
         </div>
         <div id="info-pane">
+            <video id="info-bg-video" src="Flux1.AI-2025-06-21.mp4" autoplay muted loop playsinline></video>
             <div class="tab-buttons">
                 <button class="tab-button active" data-tab="item-list">Items</button>
                 <button class="tab-button" data-tab="recipe-list">Recipes</button>

--- a/style.css
+++ b/style.css
@@ -33,11 +33,29 @@ body {
 }
 
 #info-pane {
+    position: relative;
     width: 250px;
     height: 90vh;
     overflow-y: auto;
-    background: #ffffff;
+    background: rgba(255, 255, 255, 0.8);
     border-left: 1px solid #ccc;
+}
+
+#info-bg-video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: 0;
+    pointer-events: none;
+}
+
+#info-pane .tab-buttons,
+#info-pane .tab {
+    position: relative;
+    z-index: 1;
 }
 
 .tab-buttons {


### PR DESCRIPTION
## Summary
- allow a video to be used as a background for the right side info panel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685655611c44832192435785a2b971b6