### PR TITLE
Add Character tab for background video

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,12 @@
                 <button class="tab-button active" data-tab="item-list">Items</button>
                 <button class="tab-button" data-tab="recipe-list">Recipes</button>
                 <button class="tab-button" data-tab="shop">Shop</button>
+                <button class="tab-button" data-tab="character">Character</button>
             </div>
             <div id="item-list" class="tab active"></div>
             <div id="recipe-list" class="tab"></div>
             <div id="shop" class="tab"></div>
+            <div id="character" class="tab"></div>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         const itemListEl = document.getElementById('item-list');
         const recipeListEl = document.getElementById('recipe-list');
         const shopEl = document.getElementById('shop');
+        const infoPane = document.getElementById('info-pane');
 
         function refreshItemList() {
             itemListEl.innerHTML = '';
@@ -157,6 +158,7 @@ window.addEventListener('DOMContentLoaded', async () => {
               document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
               btn.classList.add('active');
               document.getElementById(btn.dataset.tab).classList.add('active');
+              infoPane.classList.toggle('show-video', btn.dataset.tab === 'character');
           });
       });
 
@@ -407,4 +409,5 @@ window.addEventListener('DOMContentLoaded', async () => {
       spawnItem(randomBaseCode());
       refreshRecipeList();
       refreshShop();
+      infoPane.classList.toggle('show-video', document.querySelector('.tab-button.active').dataset.tab === 'character');
   });

--- a/style.css
+++ b/style.css
@@ -42,6 +42,7 @@ body {
 }
 
 #info-bg-video {
+    display: none;
     position: absolute;
     top: 0;
     left: 0;
@@ -50,6 +51,10 @@ body {
     object-fit: cover;
     z-index: 0;
     pointer-events: none;
+}
+
+#info-pane.show-video #info-bg-video {
+    display: block;
 }
 
 #info-pane .tab-buttons,


### PR DESCRIPTION
## Summary
- introduce Character tab in the info pane
- hide the video unless Character tab is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68565ab60a948321b8e7f392eacae740