### PR TITLE
Improve recipe UI and item naming

### DIFF
--- a/items.json
+++ b/items.json
@@ -1,14 +1,14 @@
 [
-  {"id":1, "code":"AA", "color":"#ff5555"},
-  {"id":2, "code":"BB", "color":"#55ff55"},
-  {"id":3, "code":"CC", "color":"#5555ff"},
-  {"id":4, "code":"DD", "color":"#ffff55"},
-  {"id":5, "code":"EE", "color":"#ff55ff"},
-  {"id":6, "code":"FF", "color":"#55ffff"},
-  {"id":7, "code":"GG", "color":"#ffaa00"},
-  {"id":8, "code":"HH", "color":"#8888ff"},
-  {"id":9, "code":"II", "color":"#dd4477"},
-  {"id":10, "code":"JJ", "color":"#77dd44"},
-  {"id":11, "code":"KK", "color":"#ff8800"},
-  {"id":12, "code":"LL", "color":"#00aaff"}
+  {"id":1, "code":"AA", "name":"Sparkling Dew", "color":"#ff5555"},
+  {"id":2, "code":"BB", "name":"Moonlit Petal", "color":"#55ff55"},
+  {"id":3, "code":"CC", "name":"Sun Crystal", "color":"#5555ff"},
+  {"id":4, "code":"DD", "name":"Arcane Shard", "color":"#ffff55"},
+  {"id":5, "code":"EE", "name":"Mystic Orb", "color":"#ff55ff"},
+  {"id":6, "code":"FF", "name":"Stardust Core", "color":"#55ffff"},
+  {"id":7, "code":"GG", "name":"Ethereal Bloom", "color":"#ffaa00"},
+  {"id":8, "code":"HH", "name":"Celestial Tear", "color":"#8888ff"},
+  {"id":9, "code":"II", "name":"Faerie Feather", "color":"#dd4477"},
+  {"id":10, "code":"JJ", "name":"Dragon Scale", "color":"#77dd44"},
+  {"id":11, "code":"KK", "name":"Pixie Wing", "color":"#ff8800"},
+  {"id":12, "code":"LL", "name":"Luminous Pearl", "color":"#00aaff"}
 ]

--- a/style.css
+++ b/style.css
@@ -100,3 +100,21 @@ body {
 .tab.active {
     display: block;
 }
+
+.recipe-section {
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 8px;
+    padding-bottom: 8px;
+}
+
+.recipe-section h3 {
+    margin: 4px 0;
+    background: #f9f1ff;
+    padding: 4px;
+    border-radius: 4px;
+}
+
+.recipe-line {
+    padding-left: 8px;
+    margin-bottom: 2px;
+}


### PR DESCRIPTION
## Summary
- add cute alchemy-themed item names
- group recipes by result with more detailed info
- style recipe tab sections

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68566d4fcd2c832183a40becb34e7b83