### PR TITLE
Add system tab for clearing saved progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,11 +26,16 @@
                 <button class="tab-button" data-tab="recipe-list">Recipes</button>
                 <button class="tab-button" data-tab="shop">Shop</button>
                 <button class="tab-button" data-tab="character">Character</button>
+                <button class="tab-button" data-tab="system">System</button>
             </div>
             <div id="item-list" class="tab active"></div>
             <div id="recipe-list" class="tab"></div>
             <div id="shop" class="tab"></div>
             <div id="character" class="tab"></div>
+            <div id="system" class="tab">
+                <p class="warning">このボタンを押すとデータが初期化されます</p>
+                <button id="clear-progress-btn">進行状況を初期化</button>
+            </div>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -97,8 +97,10 @@ window.addEventListener('DOMContentLoaded', async () => {
         let gatherIntervalId = null;
 
         const SAVE_KEY = 'mergeGameState';
+        let cookieUpdatesEnabled = true;
 
         function saveState() {
+            if (!cookieUpdatesEnabled) return;
             const data = {
                 scores,
                 recipeBookPurchased,
@@ -198,6 +200,14 @@ window.addEventListener('DOMContentLoaded', async () => {
               infoPane.classList.toggle('show-video', btn.dataset.tab === 'character');
           });
       });
+
+      const clearBtn = document.getElementById('clear-progress-btn');
+      if (clearBtn) {
+          clearBtn.addEventListener('click', () => {
+              document.cookie = `${SAVE_KEY}=; max-age=0; path=/`;
+              cookieUpdatesEnabled = false;
+          });
+      }
 
     const endpointRadius = 30;
     const endpointX = app.renderer.width - endpointRadius - 20;

--- a/style.css
+++ b/style.css
@@ -118,3 +118,7 @@ body {
     padding-left: 8px;
     margin-bottom: 2px;
 }
+
+.warning {
+    color: red;
+}


### PR DESCRIPTION
## Summary
- add new System tab with red text warning and button
- allow clearing saved cookie while disabling saves for the session
- show warning style in CSS

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_6856735829b083219a7fffd8a0718f6e