### PR TITLE
Add reputation based backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ not consume reputation, but it will periodically generate new items that cannot
 be created through merging. Game progress such as your resources and shop
 purchases is saved to a cookie so you can continue later.
 
+The background image of the game area changes depending on your reputation
+rank. Place images named `background1.png`, `background2.png`, ... alongside the
+game files to customize the look for each rank.
+
 ## How to run
 
 Simply open `index.html` in a modern web browser. PixiJS is loaded from a CDN so no build step is required.

--- a/main.js
+++ b/main.js
@@ -48,6 +48,18 @@ window.addEventListener('DOMContentLoaded', async () => {
           }
           return label;
       }
+
+      function getReputationIndex(value) {
+          let index = 0;
+          for (let i = 0; i < reputationRanks.length; i++) {
+              if (value >= reputationRanks[i].threshold) {
+                  index = i;
+              } else {
+                  break;
+              }
+          }
+          return index;
+      }
       
         const itemListEl = document.getElementById('item-list');
         const recipeListEl = document.getElementById('recipe-list');
@@ -269,6 +281,8 @@ window.addEventListener('DOMContentLoaded', async () => {
         scoreEls.reputation.textContent = `Reputation: ${scores.reputation} (${label})`;
         scoreEls.magic.textContent = `Magic: ${scores.magic}`;
         scoreEls.money.textContent = `Money: ${scores.money}`;
+        const rankIndex = getReputationIndex(scores.reputation);
+        canvasContainer.style.backgroundImage = `url('background${rankIndex + 1}.png')`;
         if (typeof refreshShop === 'function') refreshShop();
         if (typeof saveState === 'function') saveState();
     }

--- a/style.css
+++ b/style.css
@@ -16,7 +16,7 @@ body {
     flex: 1;
     height: 90vh;
     position: relative;
-    background-image: url('background1.png');
+    /* Background image will be set dynamically based on reputation rank */
     background-size: cover;
     background-position: center;
 }


### PR DESCRIPTION
## Summary
- dynamically load background image in the main game panel according to reputation rank
- clean up default style for canvas container
- document new background feature in README

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68567a1d908c83218b9a89c847da4470