### PR TITLE
Improve recipe book UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Recipes indicate whether the result is a final item. There are now five
 possible final results. Final items disappear immediately when created and are
 turned into score instead of remaining on the board.
 You can also open the **Shop** tab to buy recipe books which unlock extra merge
-combinations. Multiple books can be purchased over time, each introducing new
-recipes that lead to higher tier items. As your reputation increases you can
-purchase several **Gathering Sites**. These sites periodically generate unique
-items and can be toggled on or off. Game progress such as your resources and
-shop purchases is saved to a cookie so you can continue later.
+combinations. All recipe books are listed vertically in the shop. Once
+purchased, a book's button is greyed out and disabled. Multiple books can be
+purchased over time, each introducing new recipes that lead to higher tier
+items. As your reputation increases you can purchase several **Gathering
+Sites**. These sites periodically generate unique items and can be toggled on or
+off. Game progress such as your resources and shop purchases is saved to a
+cookie so you can continue later.
 
 The background image of the game area changes depending on your reputation
 rank. Place images named `background1.png`, `background2.png`, ... alongside the

--- a/main.js
+++ b/main.js
@@ -236,29 +236,33 @@ window.addEventListener('DOMContentLoaded', async () => {
         function refreshShop() {
             shopEl.innerHTML = '';
 
-            const bookBtn = document.createElement('button');
-            if (purchasedRecipeBooks >= recipeBooks.length) {
-                bookBtn.textContent = 'All Recipe Books Purchased';
-                bookBtn.disabled = true;
-            } else {
-                const book = recipeBooks[purchasedRecipeBooks];
-                bookBtn.textContent = `Buy Recipe Book ${purchasedRecipeBooks + 1} ($${book.cost})`;
-                bookBtn.title = getRecipesTooltip(book.recipes);
-                bookBtn.disabled = scores.money < book.cost;
-                bookBtn.addEventListener('click', () => {
-                    if (scores.money < book.cost) return;
-                    scores.money -= book.cost;
-                    Object.entries(book.recipes).forEach(([k, v]) => { mergeRules[k] = v; });
-                    purchasedRecipeBooks++;
-                    updateScores();
-                    refreshRecipeList();
-                    refreshShop();
-                });
-            }
-            shopEl.appendChild(bookBtn);
+            recipeBooks.forEach((book, idx) => {
+                const btn = document.createElement('button');
+                btn.className = 'shop-button';
+                if (idx < purchasedRecipeBooks) {
+                    btn.textContent = `Recipe Book ${idx + 1} Purchased`;
+                    btn.disabled = true;
+                    btn.classList.add('purchased');
+                } else {
+                    btn.textContent = `Buy Recipe Book ${idx + 1} ($${book.cost})`;
+                    btn.title = getRecipesTooltip(book.recipes);
+                    btn.disabled = scores.money < book.cost;
+                    btn.addEventListener('click', () => {
+                        if (scores.money < book.cost) return;
+                        scores.money -= book.cost;
+                        Object.entries(book.recipes).forEach(([k, v]) => { mergeRules[k] = v; });
+                        purchasedRecipeBooks = Math.max(purchasedRecipeBooks, idx + 1);
+                        updateScores();
+                        refreshRecipeList();
+                        refreshShop();
+                    });
+                }
+                shopEl.appendChild(btn);
+            });
 
             gatherSites.forEach((site, idx) => {
                 const btn = document.createElement('button');
+                btn.className = 'shop-button';
                 if (site.purchased) {
                     if (site.active) {
                         btn.textContent = `Gather Site ${idx + 1} Active (click to disable)`;

--- a/style.css
+++ b/style.css
@@ -122,3 +122,13 @@ body {
 .warning {
     color: red;
 }
+
+.shop-button {
+    display: block;
+    width: 100%;
+    margin: 4px 0;
+}
+
+.shop-button.purchased {
+    opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- list all recipe books in the shop at once
- disable and grey out purchased books
- style shop buttons to display vertically
- mention the new shop layout in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856894000d88321ae371d64f64726b6