### PR TITLE
Add extra recipe books and gathering site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ more variety while playing. Some advanced recipes now require spending Magic to
 complete the merge. If you don't have enough Magic, those merges will fail.
 Drag a finished item to the dark circle in the bottom-right corner to convert it
 into score. Items that can still be merged will simply bounce off of this zone.
-Recipes indicate whether the result is a final item. There are now five
+Recipes indicate whether the result is a final item. There are now several
 possible final results. Final items disappear immediately when created and are
 turned into score instead of remaining on the board.
 You can also open the **Shop** tab to buy recipe books which unlock extra merge

--- a/items.json
+++ b/items.json
@@ -14,5 +14,11 @@
   {"id":13, "code":"MM", "name":"Glowing Crystal", "color":"#cc33ff"},
   {"id":14, "code":"NN", "name":"Ancient Bark", "color":"#33cc33"},
   {"id":15, "code":"OO", "name":"Mystic Flame", "color":"#ffcc33"},
-  {"id":16, "code":"PP", "name":"Arcane Crown", "color":"#cc6633"}
+  {"id":16, "code":"PP", "name":"Arcane Crown", "color":"#cc6633"},
+  {"id":17, "code":"QQ", "name":"Divine Relic", "color":"#ffaaaa"},
+  {"id":18, "code":"RR", "name":"Eldritch Essence", "color":"#aaffaa"},
+  {"id":19, "code":"SS", "name":"Chrono Shard", "color":"#aaaaff"},
+  {"id":20, "code":"TT", "name":"Void Crystal", "color":"#ffaa55"},
+  {"id":21, "code":"UU", "name":"Celestial Stone", "color":"#55aaff"},
+  {"id":22, "code":"VV", "name":"Mystic Crown", "color":"#dd55ff"}
 ]

--- a/main.js
+++ b/main.js
@@ -142,6 +142,27 @@ window.addEventListener('DOMContentLoaded', async () => {
                     'MM+NN': 'OO',
                     'II+JJ': 'PP'
                 }
+            },
+            {
+                cost: 40,
+                recipes: {
+                    'OO+PP': 'QQ',
+                    'JJ+OO': 'RR'
+                }
+            },
+            {
+                cost: 50,
+                recipes: {
+                    'QQ+PP': 'SS',
+                    'QQ+RR': 'TT'
+                }
+            },
+            {
+                cost: 60,
+                recipes: {
+                    'SS+TT': 'UU',
+                    'RR+UU': 'VV'
+                }
             }
         ];
 
@@ -159,7 +180,8 @@ window.addEventListener('DOMContentLoaded', async () => {
 
         const gatherSites = [
             { repRequirement: 5, itemCodes: ['KK', 'LL'], interval: 3000, purchased: false, active: false, timerId: null },
-            { repRequirement: 20, itemCodes: ['MM', 'NN'], interval: 4000, purchased: false, active: false, timerId: null }
+            { repRequirement: 20, itemCodes: ['MM', 'NN'], interval: 4000, purchased: false, active: false, timerId: null },
+            { repRequirement: 50, itemCodes: ['OO', 'PP'], interval: 5000, purchased: false, active: false, timerId: null }
         ];
 
         const SAVE_KEY = 'mergeGameState';
@@ -329,7 +351,13 @@ window.addEventListener('DOMContentLoaded', async () => {
         'KK': { money: 2, reputation: 1 },
         'LL': { magic: 2, reputation: 1 },
         'OO': { magic: 5, reputation: 3 },
-        'PP': { money: 5, reputation: 4 }
+        'PP': { money: 5, reputation: 4 },
+        'QQ': { money: 6, reputation: 4 },
+        'RR': { magic: 6, reputation: 4 },
+        'SS': { money: 7, magic: 3, reputation: 5 },
+        'TT': { magic: 7, reputation: 5 },
+        'UU': { money: 8, reputation: 6 },
+        'VV': { money: 4, magic: 8, reputation: 7 }
     };
 
     function updateScores() {
@@ -387,7 +415,13 @@ window.addEventListener('DOMContentLoaded', async () => {
         'GG+GG': 2,
         'HH+HH': 3,
         'MM+NN': 2,
-        'II+JJ': 4
+        'II+JJ': 4,
+        'OO+PP': 5,
+        'JJ+OO': 4,
+        'QQ+PP': 6,
+        'QQ+RR': 6,
+        'SS+TT': 8,
+        'RR+UU': 9
     };
 
     loadState();


### PR DESCRIPTION
## Summary
- expand item list with six new advanced items
- introduce three more purchasable recipe books
- add a third gathering site option
- increase endpoint rewards for new items
- note that the game now has several possible final results

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68568a6818708321a365ba6395a1cb34