### PR TITLE
Add two extra gathering sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can also open the **Shop** tab to buy recipe books which unlock extra merge
 combinations. All recipe books are listed vertically in the shop. Once
 purchased, a book's button is greyed out and disabled. Multiple books can be
 purchased over time, each introducing new recipes that lead to higher tier
-items. As your reputation increases you can purchase several **Gathering
+items. As your reputation increases you can purchase up to five **Gathering
 Sites**. These sites periodically generate unique items and can be toggled on or
 off. Game progress such as your resources and shop purchases is saved to a
 cookie so you can continue later.

--- a/main.js
+++ b/main.js
@@ -181,7 +181,10 @@ window.addEventListener('DOMContentLoaded', async () => {
         const gatherSites = [
             { repRequirement: 5, itemCodes: ['KK', 'LL'], interval: 3000, purchased: false, active: false, timerId: null },
             { repRequirement: 20, itemCodes: ['MM', 'NN'], interval: 4000, purchased: false, active: false, timerId: null },
-            { repRequirement: 50, itemCodes: ['OO', 'PP'], interval: 5000, purchased: false, active: false, timerId: null }
+            { repRequirement: 50, itemCodes: ['OO', 'PP'], interval: 5000, purchased: false, active: false, timerId: null },
+            // New gathering sites with a small selection of items each
+            { repRequirement: 100, itemCodes: ['QQ', 'RR', 'SS'], interval: 6000, purchased: false, active: false, timerId: null },
+            { repRequirement: 150, itemCodes: ['TT', 'UU', 'VV'], interval: 7000, purchased: false, active: false, timerId: null }
         ];
 
         const SAVE_KEY = 'mergeGameState';


### PR DESCRIPTION
## Summary
- introduce two new gathering sites with a small item pool
- note that you can now buy up to five gathering sites

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68568cd975b08321bea221f9762c627f