### PR TITLE
Add chronicle tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ purchased over time, each introducing new recipes that lead to higher tier
 items. As your reputation increases you can purchase up to five **Gathering
 Sites**. These sites periodically generate unique items and can be toggled on or
 off. Game progress such as your resources and shop purchases is saved to a
-cookie so you can continue later.
+cookie so you can continue later. A new **Chronicle** tab records the time
+whenever your reputation rank increases.
 
 The background image of the game area changes depending on your reputation
 rank. Place images named `background1.png`, `background2.png`, ... alongside the

--- a/index.html
+++ b/index.html
@@ -27,12 +27,14 @@
                 <button class="tab-button" data-tab="recipe-list">Recipes</button>
                 <button class="tab-button" data-tab="shop">Shop</button>
                 <button class="tab-button" data-tab="character">Character</button>
+                <button class="tab-button" data-tab="chronicle">Chronicle</button>
                 <button class="tab-button" data-tab="system">System</button>
             </div>
             <div id="item-list" class="tab active"></div>
             <div id="recipe-list" class="tab"></div>
             <div id="shop" class="tab"></div>
             <div id="character" class="tab"></div>
+            <div id="chronicle" class="tab"></div>
             <div id="system" class="tab">
                 <p class="warning">このボタンを押すとデータが初期化されます</p>
                 <button id="clear-progress-btn">進行状況を初期化</button>

--- a/main.js
+++ b/main.js
@@ -82,6 +82,18 @@ window.addEventListener('DOMContentLoaded', async () => {
         const recipeListEl = document.getElementById('recipe-list');
         const shopEl = document.getElementById('shop');
         const infoPane = document.getElementById('info-pane');
+        const chronicleEl = document.getElementById('chronicle');
+        let chronicleEntries = [];
+        let currentRankIndex = 0;
+
+        function refreshChronicle() {
+            chronicleEl.innerHTML = '';
+            chronicleEntries.forEach(entry => {
+                const div = document.createElement('div');
+                div.textContent = `${entry.time} - Lv${entry.level} ${entry.label}`;
+                chronicleEl.appendChild(div);
+            });
+        }
 
         function refreshItemList() {
             itemListEl.innerHTML = '';
@@ -212,6 +224,7 @@ window.addEventListener('DOMContentLoaded', async () => {
             const data = {
                 scores,
                 purchasedRecipeBooks,
+                chronicle: chronicleEntries,
                 gatherSites: gatherSites.map(site => ({
                     purchased: site.purchased,
                     active: site.active
@@ -237,6 +250,9 @@ window.addEventListener('DOMContentLoaded', async () => {
                     for (let i = 0; i < purchasedRecipeBooks; i++) {
                         Object.entries(recipeBooks[i].recipes).forEach(([k, v]) => { mergeRules[k] = v; });
                     }
+                }
+                if (Array.isArray(data.chronicle)) {
+                    chronicleEntries = data.chronicle;
                 }
                 if (Array.isArray(data.gatherSites)) {
                     data.gatherSites.forEach((siteData, idx) => {
@@ -383,6 +399,15 @@ window.addEventListener('DOMContentLoaded', async () => {
     function updateScores() {
         const rankIndex = getReputationIndex(scores.reputation);
         const label = getReputationLabel(scores.reputation);
+        if (rankIndex > currentRankIndex) {
+            chronicleEntries.push({
+                level: rankIndex + 1,
+                label,
+                time: formatGameTime(gameTime)
+            });
+            refreshChronicle();
+        }
+        currentRankIndex = rankIndex;
         scoreEls.reputation.textContent =
             `Reputation: ${scores.reputation} (Lv${rankIndex + 1} ${label})`;
         scoreEls.magic.textContent = `Magic: ${scores.magic}`;
@@ -445,6 +470,8 @@ window.addEventListener('DOMContentLoaded', async () => {
     };
 
     loadState();
+    currentRankIndex = getReputationIndex(scores.reputation);
+    refreshChronicle();
     updateScores();
     updateGameTime();
 


### PR DESCRIPTION
## Summary
- add new "Chronicle" tab to record when reputation ranks up
- save and load chronicle entries
- display chronicle entries and update when level increases
- document the chronicle feature

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_6856927f27308321aeb9bce26f5f8a80