### PR TITLE
Fix info pane tabs getting cut off

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ body {
 #game-wrapper {
     display: flex;
     width: 100vw;
-    overflow: hidden;
+    overflow-x: auto;
 }
 
 #canvas-container {


### PR DESCRIPTION
## Summary
- allow horizontal scrolling of the game wrapper so the info pane doesn't get truncated

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685696397de48321bf6db17187ae4853