### PR TITLE
Fix info pane tabs getting cut off

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ body {
 #game-wrapper {
     display: flex;
     width: 100vw;
-    overflow: hidden;
+    overflow-x: auto;
 }
 
 #canvas-container {
@@ -77,10 +77,12 @@ body {
 .tab-buttons {
     display: flex;
     background: #eee;
+    overflow-x: auto;
+    white-space: nowrap;
 }
 
 .tab-button {
-    flex: 1;
+    flex: 0 0 auto;
     padding: 4px;
     cursor: pointer;
     border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- allow info pane tabs to scroll horizontally so text like 'Chronicle' and 'System' isn't truncated

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685696397de48321bf6db17187ae4853