### PR TITLE
Display item earnings totals in recipe tab

### DIFF
--- a/main.js
+++ b/main.js
@@ -123,12 +123,8 @@ window.addEventListener('DOMContentLoaded', async () => {
 
                 const header = document.createElement('h3');
                 const def = itemMap[result] || { name: result, code: result };
-                const earn = itemEarnings[result] || {};
-                const earnParts = [];
-                if (earn.money) earnParts.push(`$${earn.money}`);
-                if (earn.magic) earnParts.push(`${earn.magic} Mag`);
-                if (earn.reputation) earnParts.push(`${earn.reputation} Rep`);
-                const earnTxt = earnParts.length ? ` (${earnParts.join(', ')})` : '';
+                const earn = itemEarnings[result] || { money: 0, magic: 0, reputation: 0 };
+                const earnTxt = ` ($${earn.money}, ${earn.magic} Mag, ${earn.reputation} Rep)`;
                 header.textContent = `${def.name} [${def.code}]${earnTxt}`;
                 section.appendChild(header);
 


### PR DESCRIPTION
## Summary
- always show Reputation, Magic, and Money totals next to recipe item names

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685698e5cf448321bf6a3d3181b1637d