### PR TITLE
Improve rewards tab styling

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,6 +118,7 @@ window.addEventListener('DOMContentLoaded', async () => {
                 if (reward.magic) rewardParts.push(`${reward.magic} Mag`);
                 if (reward.reputation) rewardParts.push(`${reward.reputation} Rep`);
                 const div = document.createElement('div');
+                div.className = 'reward-item';
                 div.textContent = `${def.name} [${code}] ${count}/${threshold} (Reward: ${rewardParts.join(', ')})`;
                 rewardsEl.appendChild(div);
             });

--- a/style.css
+++ b/style.css
@@ -109,6 +109,12 @@ body {
     padding-bottom: 8px;
 }
 
+.reward-item {
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 8px;
+    padding-bottom: 4px;
+}
+
 .recipe-section h3 {
     margin: 4px 0;
     background: #f9f1ff;


### PR DESCRIPTION
## Summary
- add separator style for reward items
- style rewards tab items similarly to recipes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856a88161a88321af4fd1be4e740591