### PR TITLE
Add next rank reputation info

### DIFF
--- a/main.js
+++ b/main.js
@@ -552,8 +552,14 @@ window.addEventListener('DOMContentLoaded', async () => {
             refreshChronicle();
         }
         currentRankIndex = rankIndex;
+        let nextText = '';
+        const nextRank = reputationRanks[rankIndex + 1];
+        if (nextRank) {
+            const toNext = nextRank.threshold - scores.reputation;
+            nextText = ` Next: ${toNext}`;
+        }
         scoreEls.reputation.textContent =
-            `Reputation: ${scores.reputation} (Lv${rankIndex + 1} ${label})`;
+            `Reputation: ${scores.reputation} (Lv${rankIndex + 1} ${label})${nextText}`;
         scoreEls.magic.textContent = `Magic: ${scores.magic}`;
         scoreEls.money.textContent = `Money: ${scores.money}`;
         if (equippedRobe >= 0) {


### PR DESCRIPTION
## Summary
- show reputation needed for the next level beside the current level display

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6856b20c62048321900ed6db173eaa26