### PR TITLE
Improve reward popup color

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,21 @@ game files to customize the look for each rank.
 
 ## How to run
 
-Simply open `index.html` in a modern web browser. PixiJS is loaded from a CDN so no build step is required.
+Because the game loads `items.json` via `fetch`, you need to run it from an
+HTTP server. Opening the file directly with the `file://` scheme will cause the
+request for `items.json` to fail on most browsers.
+
+You can quickly start a local server from this directory with for example:
+
+```bash
+npx serve
+```
+
+or, if Python is installed:
+
+```bash
+python3 -m http.server
+```
+
+Then navigate to the shown address (e.g. `http://localhost:3000`) and open
+`index.html` there. PixiJS is loaded from a CDN so no build step is required.

--- a/main.js
+++ b/main.js
@@ -667,6 +667,13 @@ window.addEventListener('DOMContentLoaded', async () => {
         return PIXI.Color.shared.setValue(def.color).toNumber();
     }
 
+    function brightenColor(color) {
+        const r = Math.min(255, (color >> 16) + 40);
+        const g = Math.min(255, ((color >> 8) & 0xff) + 40);
+        const b = Math.min(255, (color & 0xff) + 40);
+        return (r << 16) | (g << 8) | b;
+    }
+
     const floatingTexts = [];
     const floatDistance = Math.min(app.renderer.width, app.renderer.height) / 4;
 
@@ -689,7 +696,8 @@ window.addEventListener('DOMContentLoaded', async () => {
         if (reward.magic) parts.push(`${reward.magic} Mag`);
         if (reward.reputation) parts.push(`${reward.reputation} Rep`);
         if (parts.length === 0) return;
-        createFloatingText(parts.join(' '), x, y, colorForCode(code));
+        const color = brightenColor(colorForCode(code));
+        createFloatingText(parts.join(' '), x, y, color);
     }
 
     function spawnItem(code = 'AA', x = app.renderer.width / 2, y = app.renderer.height / 2) {


### PR DESCRIPTION
## Summary
- brighten reward popup text
- document that the game must run from an HTTP server

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856b72df24083218723657773e53d00