### PR TITLE
Fix updateScores initialization order

### DIFF
--- a/main.js
+++ b/main.js
@@ -108,8 +108,6 @@ window.addEventListener('DOMContentLoaded', async () => {
             { threshold: 600, label: () => t('rank9') }
         ];
 
-        updateScores();
-
       function getReputationLabel(value) {
           let label = reputationRanks[0].label();
           for (const rank of reputationRanks) {


### PR DESCRIPTION
## Summary
- remove early `updateScores()` call so variables are defined first

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856c85471fc83219ff8e0369cb7c3ff