### PR TITLE
Improve item icons using images

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ You can also customize the icons shown on moving items in the main area.
 This repository does not include any item images. If you want icons instead of
 colored circles, place your own square images named `item1.png`, `item2.png`,
 and so on inside an `images` folder next to the game files. Each number matches
-the `id` field of the corresponding item in `items.json`.
+the `id` field of the corresponding item in `items.json`. When an image is
+available, the item code label will automatically be hidden so only your icon is
+visible.
 
 ## How to run
 

--- a/main.js
+++ b/main.js
@@ -857,8 +857,16 @@ window.addEventListener('DOMContentLoaded', async () => {
         sprite.width = sprite.height = itemRadius * 2;
         sprite.mask = g;
 
-        const label = new PIXI.Text(def.code, {fontSize: 12, fill: 0xffffff});
+        const label = new PIXI.Text(def.code, { fontSize: 12, fill: 0xffffff });
         label.anchor.set(0.5);
+        // Hide the fallback code label once the sprite loads successfully
+        if (sprite.texture.baseTexture.valid) {
+            label.visible = false;
+        } else {
+            sprite.texture.baseTexture.on('loaded', () => {
+                label.visible = false;
+            });
+        }
 
         container.addChild(g);
         container.addChild(sprite);


### PR DESCRIPTION
## Summary
- hide fallback code labels once item images load
- document the behavior in README

## Testing
- `npm test` *(fails: could not read package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6856dcafb3888321bec3569fe63d112c