### PR TITLE
Add debug logging for item icon loading

### DIFF
--- a/main.js
+++ b/main.js
@@ -852,10 +852,20 @@ window.addEventListener('DOMContentLoaded', async () => {
         g.x = 0;
         g.y = 0;
 
-        const sprite = PIXI.Sprite.from(`images/item${def.id}.png`);
+        const spritePath = `images/item${def.id}.png`;
+        console.log(`Loading icon for item ${def.id} from ${spritePath}`);
+        const sprite = PIXI.Sprite.from(spritePath);
         sprite.anchor.set(0.5);
         sprite.width = sprite.height = itemRadius * 2;
         sprite.mask = g;
+        // Log a helpful error if the image fails to load
+        sprite.texture.baseTexture.on('error', (err) => {
+            console.error(`Failed to load ${spritePath}:`, err);
+        });
+
+        sprite.texture.baseTexture.on('loaded', () => {
+            console.log(`Loaded ${spritePath}`);
+        });
 
         const label = new PIXI.Text(def.code, { fontSize: 12, fill: 0xffffff });
         label.anchor.set(0.5);


### PR DESCRIPTION
## Summary
- log attempts to load item icons, when they succeed, and errors

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6856def744a08321859fd34d42d9e130