### PR TITLE
Add image load delay constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ the `id` field of the corresponding item in `items.json`. When an image is
 available, the item code label will automatically be hidden so only your icon is
 visible.
 
+If needed, you can change how long the game waits before warning about a
+missing icon. Adjust the `imageLoadWarningDelay` constant near the item setup in
+`main.js` to set a new timeout in milliseconds.
+
 ## How to run
 
 Because the game loads `items.json` via `fetch`, you need to run it from an

--- a/main.js
+++ b/main.js
@@ -726,6 +726,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     const repulsionRadius = 100;
     const repulsionStrength = 0.2;
+    const imageLoadWarningDelay = 1000; // ms before logging missing icon
     const mouse = { x: 0, y: 0, active: false };
 
     const mergeRules = {
@@ -873,7 +874,7 @@ window.addEventListener('DOMContentLoaded', async () => {
                 if (!sprite.texture.baseTexture.valid) {
                     console.warn(`Image still not loaded after delay: ${spritePath}`);
                 }
-            }, 1000);
+            }, imageLoadWarningDelay);
         }
 
         const label = new PIXI.Text(def.code, { fontSize: 12, fill: 0xffffff });


### PR DESCRIPTION
## Summary
- allow customizing the delay before logging missing item images
- document the new `imageLoadWarningDelay` setting

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6856e4f5d49c83219ea37f5b9ac79b0d