### PR TITLE
Add image load delay constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ the `id` field of the corresponding item in `items.json`. When an image is
 available, the item code label will automatically be hidden so only your icon is
 visible.
 
+If an icon doesn't load despite being reachable in your browser, open the
+included `image-test.html` file. Add a query parameter like
+`?path=images/item3.png` to have PixiJS attempt to load that image and report the
+result in the console. This helps verify whether PixiJS can access the image at
+all.
+
+If needed, you can change how long the game waits before warning about a
+missing icon. Adjust the `imageLoadWarningDelay` constant near the item setup in
+`main.js` to set a new timeout in milliseconds.
+
 ## How to run
 
 Because the game loads `items.json` via `fetch`, you need to run it from an

--- a/image-test.html
+++ b/image-test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Pixi Image Test</title>
+</head>
+<body>
+  <p>Open the browser console to see load results.</p>
+  <script src="https://pixijs.download/release/pixi.min.js"></script>
+  <script>
+    const params = new URLSearchParams(location.search);
+    const path = params.get('path') || 'images/item1.png';
+    console.log('Testing image:', path);
+    const base = PIXI.BaseTexture.from(path);
+    base.on('loaded', () => {
+      console.log('Loaded:', path, base.width + 'x' + base.height);
+    });
+    base.on('error', err => {
+      console.error('Error loading', path, err);
+    });
+  </script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -726,6 +726,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     const repulsionRadius = 100;
     const repulsionStrength = 0.2;
+    const imageLoadWarningDelay = 1000; // ms before logging missing icon
     const mouse = { x: 0, y: 0, active: false };
 
     const mergeRules = {
@@ -873,7 +874,7 @@ window.addEventListener('DOMContentLoaded', async () => {
                 if (!sprite.texture.baseTexture.valid) {
                     console.warn(`Image still not loaded after delay: ${spritePath}`);
                 }
-            }, 1000);
+            }, imageLoadWarningDelay);
         }
 
         const label = new PIXI.Text(def.code, { fontSize: 12, fill: 0xffffff });


### PR DESCRIPTION
## Summary
- allow customizing the delay before logging missing item images
- document the new `imageLoadWarningDelay` setting
- add `image-test.html` for debugging texture issues

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6856e4f5d49c83219ea37f5b9ac79b0d