### PR TITLE
Add recipe icons

### DIFF
--- a/main.js
+++ b/main.js
@@ -233,7 +233,19 @@ window.addEventListener('DOMContentLoaded', async () => {
                 const def = itemMap[result] || { name: { en: result, ja: result }, code: result };
                 const earn = itemEarnings[result] || { money: 0, magic: 0, reputation: 0, count: 0 };
                 const earnTxt = ` (${earn.count} made, ℛ${earn.reputation}, ☆${earn.magic}, $${earn.money})`;
-                header.textContent = `${getItemName(result)} [${def.code}]${earnTxt}`;
+
+                const icon = document.createElement('img');
+                icon.className = 'recipe-icon';
+                icon.alt = def.code;
+                if (def.id) {
+                    icon.src = `images/item${def.id}.png`;
+                }
+
+                const nameSpan = document.createElement('span');
+                nameSpan.textContent = `${getItemName(result)} [${def.code}]${earnTxt}`;
+
+                header.appendChild(icon);
+                header.appendChild(nameSpan);
                 section.appendChild(header);
 
                 if (byResult[result].length === 0) {

--- a/style.css
+++ b/style.css
@@ -125,6 +125,14 @@ p {
     background: #f9f1ff;
     padding: 4px;
     border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.recipe-icon {
+    width: 40px;
+    height: 40px;
 }
 
 .recipe-line {


### PR DESCRIPTION
## Summary
- show item icons next to recipe headers
- tweak recipe header style for icon display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68571527258883219f35a2074834914a